### PR TITLE
Optionally emit CSV headers

### DIFF
--- a/tgiistat.py
+++ b/tgiistat.py
@@ -194,6 +194,9 @@ def print_json(stats):
 def print_csv(stats):
     csv.writer(sys.stdout).writerow(stats.values())
 
+def print_csv_headers(stats):
+    csv.writer(sys.stdout).writerow(stats.keys())
+
 def main():
     parser = argparse.ArgumentParser(description=
 """Retrieves speed and other statistics from a Technicolor/iinet TG-1 or TG-789 modem.\n
@@ -204,6 +207,7 @@ Configure your details in tgiistat.toml\n
     parser.add_argument('--debug', '-d', action="store_true")
     parser.add_argument('--json', action="store_true", help="JSON output")
     parser.add_argument('--csv', action="store_true", help="CSV output")
+    parser.add_argument('--csv-headers', action="store_true", help="CSV-style headers")
     # --parse is useful for debugging parse() from a saved broadband-bridge-modal.lp html file
     parser.add_argument('--parse', type=argparse.FileType('r'), help="Parse html from a file", metavar='saved.html')
 
@@ -226,6 +230,8 @@ Configure your details in tgiistat.toml\n
     if args.json:
         print_json(stats)
     elif args.csv:
+        if args.csv_headers:
+            print_csv_headers(stats)
         print_csv(stats)
     else:
         print_plain(stats)


### PR DESCRIPTION
```
$ python tgiistat.py --csv --csv-headers
up_rate,down_rate,up_maxrate,down_maxrate,up_power,down_power,up_noisemargin,down_noisemargin,up_transferred,down_transferred,up_attenuation1,down_attenuation1,dsl_uptime,dsl_mode,dsl_type,dsl_status
640,7130,690,7940,19.2,12.4,9.3,7.6,845.69,2499.19,29.7,48.0,8499,Interleaved,ADSL2+,Up
```
